### PR TITLE
Use transferrable objects to speed up transfers between web workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Async resize Uint8Array with RGBA image.
   - __unsharpThreshold__ - 0..100. Default - `0`. Try 10 for begibing.
   - __dest__ - Optional. Output buffer to write data. Help to avoid data copy
     if no WebWorkers available. Callback will return result buffer anyway.
+  - __transferable__ - Optional. Whether to use 
+    [transferable objects](http://updates.html5rocks.com/2011/12/Transferable-Objects-Lightning-Fast).
+    Faster, but you cannot use the source buffer afterward.
 - __callback(err, output)__ - function to call after resize complete:
   - __err__ - error if happened.
   - __output__ - Uint8Array with resized RGBA image data.

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function resizeBuffer(options, callback) {
 
   var _opts = {
     src:      options.src,
-    dest:     options.dest,
+    dest:     null,
     width:    options.width|0,
     height:   options.height|0,
     toWidth:  options.toWidth|0,
@@ -73,9 +73,14 @@ function resizeBuffer(options, callback) {
       wr.terminate();
     };
 
-    wr.postMessage(_opts);
+    if (options.transferable) {
+      wr.postMessage(_opts, [ options.src.buffer ]);
+    } else {
+      wr.postMessage(_opts);
+    }
 
   } else {
+    _opts.dest = options.dest;
     resize(_opts, callback);
   }
 }
@@ -111,7 +116,8 @@ function resizeCanvas(from, to, options, callback) {
     quality:  options.quality,
     alpha:    options.alpha,
     unsharpAmount:    options.unsharpAmount,
-    unsharpThreshold: options.unsharpThreshold
+    unsharpThreshold: options.unsharpThreshold,
+    transferable: true
   };
 
   resizeBuffer(_opts, function (err/*, output*/) {

--- a/lib/resize_worker.js
+++ b/lib/resize_worker.js
@@ -12,7 +12,7 @@ module.exports = function(self) {
         return;
       }
 
-      self.postMessage({ output: output });
+      self.postMessage({ output: output }, [ output.buffer ]);
     });
   };
 };


### PR DESCRIPTION
This uses [transferrable objects](http://updates.html5rocks.com/2011/12/Transferable-Objects-Lightning-Fast) to speed up buffer transfers between web workers so there are no copies.  On my machine in Chrome, this speeds the demo up by about 100ms. On the highest quality setting with no unsharp, without transferrable objects I see an average of around 450ms for the resize. With transferrable objects, I see an average of around 350ms.  The difference is similar in Firefox.
