### PR TITLE
Reuse the same worker instead of creating a new one for each call

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,9 @@ if (WORKER) {
 
 var resize       = require('./lib/resize');
 var resizeWorker = require('./lib/resize_worker');
-
+if (WORKER) {
+  var wr = require('webworkify')(resizeWorker);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Helpers
@@ -33,8 +35,6 @@ function isFunction(obj) { return _class(obj) === '[object Function]'; }
 // RGBA buffer async resize
 //
 function resizeBuffer(options, callback) {
-  var wr;
-
   var _opts = {
     src:      options.src,
     dest:     options.dest,
@@ -49,8 +49,6 @@ function resizeBuffer(options, callback) {
   };
 
   if (WORKER && exports.WW) {
-    wr = require('webworkify')(resizeWorker);
-
     wr.onmessage = function(ev) {
       var i, l,
           dest = options.dest,
@@ -70,7 +68,6 @@ function resizeBuffer(options, callback) {
         }
       }
       callback(ev.data.err, output);
-      wr.terminate();
     };
 
     wr.postMessage(_opts);


### PR DESCRIPTION
This reduces the average demo resize times by another 20-30ms on top of my other PR (#6) by reusing the same worker for all resizes rather than spawning a new one each time. This obviously assumes that you're only resizing one image at a time, but I'd say this is the common case.  Really there should be some kind of thread pool with one thread for each core or something.
