### PR TITLE
Fix error in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ bower install pica
 API
 ---
 
-### .resizeCanvas(options, callback)
+### .resizeCanvas(from, to, options, callback)
 
 Resize image from one canvas to another. Sizes are taken from canvas.
 


### PR DESCRIPTION
I first thought that from, to, should also go in the options, like the signature suggests.