### PR TITLE
fix memory leak cleanup of objecturl used to create worker

### DIFF
--- a/lib/resize_js_ww.js
+++ b/lib/resize_js_ww.js
@@ -25,7 +25,6 @@ var workersPool = new Pool(function () {
 });
 
 var running = {};
-var iscleanUp = false;
 
 function resize_js_ww(from, to, options, callback) {
   var toCtx = to.getContext('2d', { alpha: Boolean(options.alpha) });

--- a/lib/resize_js_ww.js
+++ b/lib/resize_js_ww.js
@@ -25,6 +25,7 @@ var workersPool = new Pool(function () {
 });
 
 var running = {};
+var iscleanUp = false;
 
 function resize_js_ww(from, to, options, callback) {
   var toCtx = to.getContext('2d', { alpha: Boolean(options.alpha) });
@@ -83,6 +84,8 @@ function resize_js_ww(from, to, options, callback) {
       var imageDataTo, output, dest;
 
       worker.release();
+       //release from memory objecturl used to create url
+      window.URL.revokeObjectURL(worker.value.objectURL);
 
       if (!running[id]) {
         next(true);


### PR DESCRIPTION
There was memory leak issue with cleanup of object URL used for creating the worker
by revoking the url attached to the worker object