### PR TITLE
Use WASM build toolchain from Docker

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,33 +1,46 @@
 ## Compiling webassembly code
 
-To build wasm code you should install llvm & binaryen.
-Note, `emsdk` DOES NOT supports natively some 64bit operations
-and may not work. Also there are some minor interface differences,
-see commented code in `mathlib.js` file and Makefile source.
+To build wasm code you should have Docker installed.
 
-Short instructions for linux (tested in Ubuntu 14.04):
+Once you have done it the wasm code can be build by running
 
 ```bash
-export WORKDIR=~/llvmwasm; mkdir -p $WORKDIR
-export INSTALLDIR=$WORKDIR
-
-sudo apt-get install g++-multilib
-
-cd $WORKDIR
-svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm
-
-cd $WORKDIR/llvm/tools
-svn co http://llvm.org/svn/llvm-project/cfe/trunk clang
-
-mkdir $WORKDIR/llvm-build
-cd $WORKDIR/llvm-build
-cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=$INSTALLDIR -DLLVM_TARGETS_TO_BUILD= -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly $WORKDIR/llvm
-make
-make install
-
-cd $WORKDIR
-git clone https://github.com/WebAssembly/binaryen.git
-cd $WORKDIR/binaryen
-cmake .
-make
+make wasm
 ```
+This command uses `docker run nodeca/pica-toolchain` to pull the
+toolchain from Docker Hub and run compiler and linker from the 
+container.
+
+The local version of the toolchain image could be updated by running
+
+```bash
+docker pull nodeca/pica-toolchain
+```
+
+If you want for some reason rebuild the image, it could be done by
+running
+
+```bash
+make build-toolchain
+```
+
+The newly build toolchain could also be published to Docker Hub by
+running
+
+```bash
+make publish-toolchain
+```
+
+Alternatively, if you want to avoid using Docker, it is possible to
+build the toolchain on a Debian-based system using `toolchain/setup.sh`
+script and then build wasm code by running
+
+```bash
+make wasm WASM_RUN=""
+```
+so that `make` would use the toolchain from `PATH`.
+
+There is also `wasm-emsk` target in the Makefile that uses `emcc`, but
+note that  `emsdk` DOES NOT supports natively some 64bit operations
+and may not work. Also there are some minor interface differences,
+see commented code in `mathlib.js` file and Makefile source.

--- a/toolchain/Dockerfile
+++ b/toolchain/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:16.04
+
+ARG WORKDIR=/workdir
+ARG INSTALLDIR=/opt
+WORKDIR $WORKDIR
+
+RUN mkdir -p $WORKDIR
+COPY setup.sh $WORKDIR/
+
+RUN apt-get update && \
+  apt-get install -y g++-multilib subversion git cmake python && \
+  bash setup.sh && \
+  rm -rf $WORKDIR/* && \
+  apt-get autoremove -y --purge g++-multilib subversion git cmake python
+
+ENV PATH=$INSTALLDIR/bin:$PATH

--- a/toolchain/setup.sh
+++ b/toolchain/setup.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+[ -n "$WORKDIR" ] && [ -n "$INSTALLDIR" ] || { echo "WORKDIR and INSTALLDIR should be set"; exit 1; }
+
+set -e -x
+LLVM_REVISION=300398
+BINARYEN_COMMIT=ec66e273e350c3d48df0ccaaf73c53b14485848f
+
+mkdir -p $WORKDIR
+cd $WORKDIR
+# install llvm with support for webassembly target
+svn co -q https://llvm.org/svn/llvm-project/llvm/trunk@$LLVM_REVISION llvm
+cd $WORKDIR/llvm/tools
+svn co -q https://llvm.org/svn/llvm-project/cfe/trunk@$LLVM_REVISION clang
+mkdir -p $WORKDIR/llvm-build
+cd $WORKDIR/llvm-build
+cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=$INSTALLDIR -DLLVM_TARGETS_TO_BUILD= -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold" -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=gold" -DCMAKE_BUILD_TYPE=MinSizeRel $WORKDIR/llvm
+make -j $(nproc)
+make install
+# install binaryen
+mkdir -p $WORKDIR/binaryen
+cd $WORKDIR/binaryen
+git init
+git fetch https://github.com/WebAssembly/binaryen.git
+git checkout $BINARYEN_COMMIT
+cmake -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold" -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=gold" -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=$INSTALLDIR .
+make -j $(nproc)
+make install


### PR DESCRIPTION
Hi!

The way WebAssembly toolchain, required for Pica development, is supposed to be set up now, cannot be called robust. In order to compile anything for WebAssembly target one has to install a bunch of exotic (at least from a point of view of a javascript developer) packages like `subversion` and `cmake` and then compile `llvm` and `binaryen`, so that the whole process could easily take a few hours.

Also the development instructions recommend to use `trunk`/`master` versions of `llvm` and `binaryen` packages respectively, without specifying any concrete commits. It means that different developers may get different results if they check out these projects at different moments of time.

This pull request mitigates the described above issue by using WebAssembly toolchain from a Docker container. In this setup anyone can build the `wasm` target by just running

```bash
make wasm
```
with assumption of having Docker installed on the machine. Docker would try to use image `nodeca/pica-toolchain` from the local machine and, if it is not present, pull it from Docker Hub registry. Then `make` would run all WebAssembly-related commands using a container created from this image.

If someone needs to rebuild the toolchain, in order to modify it or because of some other reason, it could be done by running `make build-toolchain`. The source files for toolchain are located at the `toolchain` subdirectory. Note that they contain specific commits for `llvm` and `binaryen` repositories, so the toolchain builds should be reproducible.

However, while the image `nodeca/pica-toolchain` is not published, `make wasm` command would fail. To make it possible to try the new toolchain setup without previously creating `nodeca/pica-toolchain` repository at Docker Hub, I created a repository `arodin/pica-toolchain` and pushed a modified version of this pull request to [this branch](https://github.com/a-rodin/pica/tree/docker-my-dockerhub). You can clone that modified branch and test the updated `make wasm` command from it, it should work because that branch uses image `arodin/pica-toolchain` instead of `nodeca/pica-toolchain`.