### PR TITLE
Fix qualityArgument in toBlob example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ pica.resize(from, to, {
 
 // Resize & convert to blob
 pica.resize(from, to)
-  .then(result => pica.toBlob(result, 'image/jpeg', 90))
+  .then(result => pica.toBlob(result, 'image/jpeg', 0.90))
   .then(blob => console.log('resized to canvas & created blob!'));
 ```
 


### PR DESCRIPTION
The [qualityArgument](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob) is supposed to be a value between 0 and 1. The ReadMe is confusing since it specifies `90` but its value is passed directly to the native method. I think this is likely just a typo.