### PR TITLE
Fix ES6 syntax not recognized on older browsers

### DIFF
--- a/lib/mm_resize/convolve.js
+++ b/lib/mm_resize/convolve.js
@@ -131,6 +131,6 @@ function convolveVertically(src, dest, srcW, srcH, destW, filters) {
 
 
 module.exports = {
-  convolveHorizontally,
-  convolveVertically
+  convolveHorizontally: convolveHorizontally,
+  convolveVertically: convolveVertically
 };


### PR DESCRIPTION
Apparently the library crashes on IE11 due to the syntax of this file, which is too new for older browsers.