### PR TITLE
Fix compatibility issue with older browsers

### DIFF
--- a/lib/mathlib.js
+++ b/lib/mathlib.js
@@ -6,15 +6,15 @@
 'use strict';
 
 
-const inherits  = require('inherits');
-const Multimath = require('multimath');
+var inherits  = require('inherits');
+var Multimath = require('multimath');
 
-const mm_unsharp_mask = require('multimath/lib/unsharp_mask');
-const mm_resize       = require('./mm_resize');
+var mm_unsharp_mask = require('multimath/lib/unsharp_mask');
+var mm_resize       = require('./mm_resize');
 
 
 function MathLib(requested_features) {
-  const __requested_features = requested_features || [];
+  var __requested_features = requested_features || [];
 
   var features = {
     js:   __requested_features.indexOf('js') >= 0,

--- a/lib/mathlib.js
+++ b/lib/mathlib.js
@@ -16,7 +16,7 @@ const mm_resize       = require('./mm_resize');
 function MathLib(requested_features) {
   const __requested_features = requested_features || [];
 
-  let features = {
+  var features = {
     js:   __requested_features.indexOf('js') >= 0,
     wasm: __requested_features.indexOf('wasm') >= 0
   };
@@ -37,7 +37,7 @@ inherits(MathLib, Multimath);
 
 
 MathLib.prototype.resizeAndUnsharp = function resizeAndUnsharp(options, cache) {
-  let result = this.resize(options, cache);
+  var result = this.resize(options, cache);
 
   if (options.unsharpAmount) {
     this.unsharp_mask(


### PR DESCRIPTION
This file is not correctly parsed by Firefox and other browsers that do not support the `let` keyword yet.