### PR TITLE
Add a note about webpack into the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,32 @@ load module in node.js style as `require('pica')` - your project MUST
 be compiled with [browserify](https://github.com/substack/node-browserify)
 to properly use Web Workers. In other case - use `require('pica/dist/pica')`.
 
+webpack:
+
+If you use Webpack to bundle your application, you must to define a resolve
+alias into your webpack config, like this:
+
+```js
+{
+    ....
+    resolve: {
+        alias: {
+               // Use compiled pica files from /dist folder
+               pica: 'pica/dist/pica.js',
+        },
+        ...
+    }
+    ...
+}
+```
+
+After that, you will be able to use pica as usual:
+
+```js
+import Pica from 'pica';
+const pica = Pica();
+pica.resize(img, canvas).then(...);
+```
 
 Use
 ---

--- a/README.md
+++ b/README.md
@@ -80,22 +80,19 @@ load module in node.js style as `require('pica')` - your project MUST
 be compiled with [browserify](https://github.com/substack/node-browserify)
 to properly use Web Workers. In other case - use `require('pica/dist/pica')`.
 
-webpack:
+**Webpack notice**
 
-If you use Webpack to bundle your application, you must to define a resolve
-alias into your webpack config, like this:
+If you use Webpack to bundle your application, you probably need to define a [resolve
+alias](https://webpack.js.org/configuration/resolve/#resolve-alias) into your webpack config, like this:
 
 ```js
 {
-    ....
-    resolve: {
-        alias: {
-               // Use compiled pica files from /dist folder
-               pica: 'pica/dist/pica.js',
-        },
-        ...
-    }
-    ...
+  resolve: {
+    alias: {
+      // Use compiled pica files from /dist folder
+      pica: 'pica/dist/pica.js',
+    },
+  }
 }
 ```
 


### PR DESCRIPTION
This note will be helpful for peoples who want to use pica into their applications bundled with webpack and who run into troubles that described into https://github.com/nodeca/pica/issues/149, https://github.com/nodeca/pica/issues/70, https://github.com/nodeca/pica/pull/72.