### PR TITLE
fix: clean state for output size patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Resize image from one canvas (or image) to another. Sizes are
 taken from source and destination objects.
 
 - __from__ - source canvas or image.
-- __to__ - destination canvas.
+- __to__ - destination canvas, its size is supposed to be non-zero.
 - __options__ - quality (number) or object:
   - __quality__ - 0..3. Default = `3` (lanczos, win=3).
   - __alpha__ - use alpha channel. Default = `false`.
@@ -204,8 +204,8 @@ binary data (for example, if you decode jpeg files "manually").
   - __src__ - Uint8Array with source data.
   - __width__ - src image width.
   - __height__ - src image height.
-  - __toWidth__ - output width.
-  - __toHeigh__ - output height.
+  - __toWidth__ - output width, >=0, in pixels.
+  - __toHeigh__ - output height, >=0, in pixels.
   - __quality__ - 0..3. Default = `3` (lanczos, win=3).
   - __alpha__ - use alpha channel. Default = `false`.
   - __unsharpAmount__ - >=0, in percents. Default = `0` (off).

--- a/index.js
+++ b/index.js
@@ -214,6 +214,11 @@ Pica.prototype.resize = function (from, to, options) {
   opts.width    = from.naturalWidth || from.width;
   opts.height   = from.naturalHeight || from.height;
 
+  // Prevent stepper from infinite loop
+  if (to.width === 0 || to.height === 0) {
+    return Promise.reject(new Error(`Invalid output size: ${to.width}x${to.height}`));
+  }
+
   if (opts.unsharpRadius > 2) opts.unsharpRadius = 2;
 
   let canceled    = false;

--- a/test/pica.js
+++ b/test/pica.js
@@ -9,7 +9,7 @@ const Canvas = require('canvas');
 describe('API', function () {
 
   // Need node 8 to run
-  it('Upscale (unexpected use) via wasm shoudl not crash', function () {
+  it('Upscale (unexpected use) via wasm should not crash', function () {
     const p = _pica({ features: [ 'wasm' ] });
 
     const input = new Uint8Array(500 * 500 * 4);
@@ -36,6 +36,20 @@ describe('API', function () {
 
     return _pica().resize(src, to).then(result => {
       assert.strictEqual(result, to);
+    });
+  });
+
+  it('Resize with bad output size should fail', function () {
+    let src = new Canvas();
+    src.width = 1000;
+    src.height = 1000;
+    let to = new Canvas();
+    to.width = 0;
+    to.height = 0;
+    return _pica().resize(src, to)
+    .then(() => { throw new Error('Resize should fail'); })
+    .catch(err => {
+      assert.equal(err.message, 'Invalid output size: 0x0');
     });
   });
 


### PR DESCRIPTION
This PR is same with #156 without touching `dist`.

To prevent such case we can use a simple setup:

1. Delete `dist/*` and commit.
2. Add `/dist/` to `.gitignore`.

Since in  package.json we've added `dist` in the `"files"` field, this change won't affect NPM tarball.