### PR TITLE
Update babelify, babel and webworkify

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ npm install pica
 Transforms plugins for build via browserify:
 
 ```sh
-npm install babelify babel-core babel-preset-es2015
+npm install babelify @babel/core @babel/preset-env
 ```
 
 bower:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "babelify",
         {
           "presets": [
-            "es2015"
+            "@babel/preset-env"
           ]
         }
       ]
@@ -36,11 +36,12 @@
     "inherits": "^2.0.3",
     "multimath": "^1.0.3",
     "object-assign": "^4.1.1",
-    "webworkify": "^1.3.0"
+    "webworkify": "^1.5.0"
   },
   "devDependencies": {
-    "babel-preset-es2015": "^6.24.1",
-    "babelify": "^7.3.0",
+    "@babel/core": "^7.1.2",
+    "@babel/preset-env": "^7.1.0",
+    "babelify": "^10.0.0",
     "benchmark": "^2.1.0",
     "browserify": "^16.2.3",
     "canvas": "^2.0.0",


### PR DESCRIPTION
This pr upgrades babelify to version 10.0.0, which led to changes:
*  reference packages "@babel/core" and "@babel/preset-env", not "babel-core" and "babel-preset-es2015"
* change babelify preset in package.json from "es2015" to "@babel/preset-env"
* and I also upgraded webworkify, as it's also used when compiling with browserify

Babel blog about upgrading: https://babeljs.io/docs/en/env

I've tested this in a browserify project of mine that uses pica, using "npm install pica babelify @babel/core @babel/preset-env". Works fine.