### PR TITLE
Updated JS object syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ if (typeof navigator !== 'undefined') {
 
 const DEFAULT_PICA_OPTS = {
   tile: 1024,
-  concurrency,
+  concurrency: concurrency,
   features: [ 'js', 'wasm', 'ww' ],
   idle: 2000
 };


### PR DESCRIPTION
The library is throwing error in IE because of new ES6 syntax. Hence falling back to the ES5 syntax.