### PR TITLE
Clarify note about old iOS bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ Here is a short list of problems you can face:
   - Due to JS security restrictions, you can process images
     from the same domain or local files only. If you load images from
     remote domain use proper `Access-Control-Allow-Origin` header.
-  - iOS has resource limits for canvas size & image size.
-    Look [here](https://github.com/stomita/ios-imagefile-megapixel)
-    for details and possible solutions.
   - If you plan to show images on screen after load, you should parse
     `exif` header to get proper orientation. Images can be rotated.
 - Saving image:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Here is a short list of problems you can face:
   - Due to JS security restrictions, you can process images
     from the same domain or local files only. If you load images from
     remote domain use proper `Access-Control-Allow-Origin` header.
+  - iOS has a memory limits for canvas elements, that may cause 
+    problems in some cases, [more details](https://github.com/nodeca/pica/wiki/iOS-Memory-Limit).
   - If you plan to show images on screen after load, you should parse
     `exif` header to get proper orientation. Images can be rotated.
 - Saving image:


### PR DESCRIPTION
Thanks for a great library! 🎖 

I think we can drop this:

- I'm pretty sure this is the correct bug[1] and if so, it's fixed. 
- I haven't seen this on any device for the past few years.
- This related StackOverflow question[2] has had no activity for 5 years, i.e. people aren't seeing this anymore.

[1] https://bugs.webkit.org/show_bug.cgi?id=134513
[2] https://stackoverflow.com/questions/11929099/html5-canvas-drawimage-ratio-bug-ios