### PR TITLE
Add createCanvas option (for pica in Service Worker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,13 @@ Create resizer instance with given config (optional):
   This option allow reuse webworkers effectively. Default 2000.
 - __concurrency__ - max webworkers pool size. Default is autodetected
   CPU count, but not more than 4.
-
+- __createCanvas__ - function which returns a new canvas, used internally
+   by pica.
+   Default returns a [\<canvas\> element](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API),
+   but this function could return an [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas)
+   instead (to run pica in a Service Worker). Function signature: createCanvas(width: number, height: number): Canvas
+     
+   
 __Important!__ Latest browsers may support resize via [createImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap).
 This feature is supported (`cib`) but disabled by default and not recommended
 for use. So:

--- a/index.js
+++ b/index.js
@@ -36,7 +36,13 @@ const DEFAULT_PICA_OPTS = {
   tile: 1024,
   concurrency,
   features: [ 'js', 'wasm', 'ww' ],
-  idle: 2000
+  idle: 2000,
+  createCanvas:  function (width, height) {
+    let tmpCanvas = document.createElement('canvas');
+    tmpCanvas.width  = width;
+    tmpCanvas.height = height;
+    return tmpCanvas;
+  }
 };
 
 
@@ -180,7 +186,7 @@ Pica.prototype.init = function () {
   if (!CAN_CREATE_IMAGE_BITMAP) {
     checkCibResize = Promise.resolve(false);
   } else {
-    checkCibResize = utils.cib_support().then(status => {
+    checkCibResize = utils.cib_support(this.options.createCanvas).then(status => {
       if (this.features.cib && features.indexOf('cib') < 0) {
         this.debug('createImageBitmap() resize supported, but disabled by config');
         return;
@@ -265,10 +271,7 @@ Pica.prototype.resize = function (from, to, options) {
 
         this.debug('Unsharp result');
 
-        let tmpCanvas = document.createElement('canvas');
-
-        tmpCanvas.width  = opts.toWidth;
-        tmpCanvas.height = opts.toHeight;
+        let tmpCanvas = this.options.createCanvas(opts.toWidth, opts.toHeight);
 
         let tmpCtx = tmpCanvas.getContext('2d', { alpha: Boolean(opts.alpha) });
 
@@ -360,9 +363,7 @@ Pica.prototype.resize = function (from, to, options) {
           //
           this.debug('Draw tile imageBitmap/image to temporary canvas');
 
-          let tmpCanvas = document.createElement('canvas');
-          tmpCanvas.width  = tile.width;
-          tmpCanvas.height = tile.height;
+          let tmpCanvas = this.options.createCanvas(tile.width, tile.height);
 
           let tmpCtx = tmpCanvas.getContext('2d', { alpha: Boolean(opts.alpha) });
           tmpCtx.globalCompositeOperation = 'copy';
@@ -538,9 +539,7 @@ Pica.prototype.resize = function (from, to, options) {
 
       if (!isLastStage) {
         // create temporary canvas
-        tmpCanvas = document.createElement('canvas');
-        tmpCanvas.width  = toWidth;
-        tmpCanvas.height = toHeight;
+        tmpCanvas = this.options.createCanvas(toWidth, toHeight);
       }
 
       return tileAndResize(from, (isLastStage ? to : tmpCanvas), opts).then(() => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,16 +67,13 @@ module.exports.cib_quality_name = function cib_quality_name(num) {
 };
 
 
-module.exports.cib_support = function cib_support() {
+module.exports.cib_support = function cib_support(createCanvas) {
   return Promise.resolve().then(() => {
-    if (typeof createImageBitmap === 'undefined' ||
-        typeof document === 'undefined') {
+    if (typeof createImageBitmap === 'undefined') {
       return false;
     }
 
-    let c = document.createElement('canvas');
-    c.width = 100;
-    c.height = 100;
+    let c = createCanvas(100, 100);
 
     return createImageBitmap(c, 0, 0, 100, 100, {
       resizeWidth: 10,


### PR DESCRIPTION
### What

Add a new "createCanvas" option to the pica constructor (optional). The default behaviour is to return a new canvas element. So there is no change to pica's current behaviour.

### Why

This change lets pica run in a Service Worker - if the developer supplies a createCanvas function which returns an OffscreenCanvas. Pica cannot run in a Service Worker right now, as it uses canvas elements internally. Canvas elements are not available in a Service Worker: there is no document object.

This change DRYs out internal canvas creation, and lets it be overridden from the outside. I suspect that running pica in a Service Worker is a rare case, so supplying a special createCanvas option seemed like a good option - it means that the main pica code does not change, and the developer is responsible for making sure pica works with the supplied createCanvas function.




