### PR TITLE
Bug fix: re-enable pica in Service Worker by adding single "Image exists" check

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -168,7 +168,8 @@ module.exports.can_use_canvas = function can_use_canvas(createCanvas) {
 // TODO: remove after it's fixed in chrome for at least 2 releases
 module.exports.cib_can_use_region = function cib_can_use_region() {
   return new Promise(resolve => {
-    if (typeof createImageBitmap === 'undefined') {
+    // `Image` check required for use in `ServiceWorker`
+    if ((typeof Image === 'undefined') || (typeof createImageBitmap === 'undefined')) {
       resolve(false);
       return;
     }


### PR DESCRIPTION
### What

Add a single `(typeof Image === 'undefined')` check inside `cib_can_use_region` function, and return false if Image is undefined.

### Why

This change lets pica run in a Service Worker again. Pica currently breaks in a Service Worker as the `cib_can_use_region` function tries to [create a new Image](https://github.com/nodeca/pica/blob/b93a4bf6661fcf3e5b71ef0c9b45f90b7fb37e05/lib/utils.js#L176
), which leads to error: `ReferenceError: Image is not defined`. Image objects are not available in a Service Worker.

This change adds an "Image object exists" check in the `cib_can_use_region` function, before a new Image is created. So `cib_can_use_region` will now return false if Image does not exist. But I think this is ok, as the function seems to check for a specific bug when `createImageBitmap` is applied to an `Image`. So both objects would need to exist.



