### PR TITLE
Add new callback when Tile was resized

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,10 @@ const DEFAULT_RESIZE_OPTS = {
   filter:           'mks2013',
   unsharpAmount:    0,
   unsharpRadius:    0.0,
-  unsharpThreshold: 0
+  unsharpThreshold: 0,
+  onTileResized:  function () {
+    this.debug('tile was resized');
+  }
 };
 
 let CAN_NEW_IMAGE_DATA            = false;
@@ -401,6 +404,7 @@ Pica.prototype.__tileAndResize = function (from, to, opts) {
         return this.__invokeResize(tileOpts, opts);
       })
       .then(result => {
+        opts.onTileResized(result);
         if (opts.canceled) return opts.cancelToken;
         stageEnv.srcImageData = null;
         return this.__landTileData(tile, result, stageEnv);


### PR DESCRIPTION
Thanks for sharing this great library, it really helps us and our multiple 100k customers in the world out there! :)

I would like to propose a small improvement as you can see in my PR.  It would give a great benefit, if the users of the library could do some action, if a single Tile was resized.
- Then it is possible to react on it, e.g. show the resized Tile in some fancy looking UI
- It would then be also possible to validate the resized Tile for some criterias

You may be wondering what the concrete use-case for us is?

- On low memory devices(phones, old devices, ...) there is the problem, that sometimes downescaled images are just black, and there is no error being thrown (this for example also happens [very unlikely and rarely] when loading original images, so it is a very underlying problem.
- The callback would help us, with validating if the resized Tile is fine, as we then can check if the Tile is black or not, and we can properly react on that case
